### PR TITLE
Commented the inner bit-field classes

### DIFF
--- a/Hg/detail/pack_array.h
+++ b/Hg/detail/pack_array.h
@@ -91,6 +91,58 @@ struct Serializer
 
 
 //  ****************************************************************************
+//  Exports arrays of bit-field values into a packed buffer.
+//
+template< typename T,
+          size_t   N,
+          typename BufferT
+        >
+struct Serializer <std::array<T,N>, BufferT, bitfield_trait>
+{
+  typedef std::array<T,N>               array_type;
+
+  typedef typename
+    array_type::value_type              bitfield_type;
+
+  typedef typename 
+    bitfield_type::value_type           value_type;
+
+  typedef BufferT                       buffer_type;
+
+  typedef nested_trait                  data_type_trait;
+
+  //  **************************************************************************
+  template <typename TraitT>
+  size_t Write( array_type     &value, 
+                buffer_type    &buffer,
+                size_t          offset)
+  {
+    size_t bytes_written = 0;
+
+    // Process each item individually.
+    const size_t k_count = N;
+    for (size_t index = 0; index < k_count; ++index)
+    {
+      // The offset for each item progressively increases
+      // by the number of bytes read from the input buffer.
+      size_t item_offset = offset + bytes_written;
+
+//      value[index].value_type();
+
+
+      //value_type t = value[index];
+      //buffer.set_data(t, 
+      //                item_offset);
+
+      bytes_written += Hg::SizeOf<bitfield_type>::value;
+    }
+
+    return bytes_written;
+  }  
+};
+
+
+//  ****************************************************************************
 //  Exports a nested_trait with each sub-item written individually.
 //
 template< typename T,

--- a/meta/bit_field/basic_list.h
+++ b/meta/bit_field/basic_list.h
@@ -1,9 +1,9 @@
-/// @file meta/BitField/basic_list.h
-/// 
-/// Defines a collector for bit-fields.
-/// 
-/// The MIT License(MIT)
-/// @copyright 2014 Paul M Watt
+//  @file meta/BitField/basic_list.h
+//  
+//  Defines a collector for bit-fields.
+//  
+//  The MIT License(MIT)
+//  @copyright 2014 Paul M Watt
 //  ****************************************************************************
 #ifndef META_BIT_FIELD_BASIC_LIST_H_INCLUDED
 #define META_BIT_FIELD_BASIC_LIST_H_INCLUDED
@@ -15,6 +15,8 @@ namespace Hg
 {
 
 //  ****************************************************************************
+//  A trait-type to define constants and common parameterized typedefs.
+//
 template< size_t    IndexT,
           typename  HostT,
           size_t    CountT
@@ -29,6 +31,8 @@ struct FieldIndex
 };
 
 //  ****************************************************************************
+//  A specialization for a bit-field representing the empty type.
+//
 template<>
 struct FieldIndex<0,MT,0>
 {
@@ -43,6 +47,9 @@ struct FieldIndex<0,MT,0>
 typedef FieldIndex<0,MT,0>     idx_empty_t;
 
 //  ****************************************************************************
+//  The base container definition for a list of bit-fields.
+//  This object contains type definitions 
+// 
 template <typename T,
           typename FieldsT>
 struct BasicBitList
@@ -50,8 +57,8 @@ struct BasicBitList
   , public bitfield_trait
 { 
   // Define each of these types for the base.
-  // This will insure the types exist if less than 
-  // eight bit-fields are defined.
+  // This will ensure the types exist if less than 
+  // the maximum number of bit-fields are defined.
   typedef idx_empty_t   idx_0;
   typedef idx_empty_t   idx_1;
   typedef idx_empty_t   idx_2;
@@ -96,40 +103,44 @@ struct BasicBitList
   enum { k_offset_0 = 0 };
 
   //  **************************************************************************
+  //  Returns the value of the entire storage buffer.
+  // 
   value_type value()
   { 
     return m_data; 
   }
 
-
   value_type            &m_data;
 
 protected:
   //  **************************************************************************
-  ///
-  ///
+  //  Prevent direct creation of this class; must use a derived class.
+  // 
   BasicBitList()
     : m_data(empty_data)
     , empty_data(0)
   { }
 
   //  **************************************************************************
-  ///
-  ///
+  //  Prevent direct creation of this class; must use a derived class.
+  // 
   BasicBitList(value_type &data_field)
     : m_data(data_field)
   { }
+                                        //   TODO: Would like to explore options 
+                                        //   for removing this data fields
+                                        //   without adding buffer validity tests.
 
-  value_type            empty_data;     ///< The MT data value field 
-                                        ///  provides a location to reference
-                                        ///  for the default constructor.
+  value_type            empty_data;     // The MT data value field 
+                                        // provides a location to reference
+                                        // for the default constructor.
 
   //  **************************************************************************
-  /// Endian swap provides a specialization to handle the unique structure 
-  /// created to provide bit-field support.
-  /// The function is declared and implemented as a friend function to simplify
-  /// the declaration and namespace lookup for proper endian order conversions.
-  ///
+  //  Endian swap provides a specialization to handle the unique structure 
+  //  created to provide bit-field support.
+  //  The function is declared and implemented as a friend function to simplify
+  //  the declaration and namespace lookup for proper endian order conversions.
+  // 
   friend inline
     field_type EndianSwap(field_type &input)
   { 

--- a/meta/bit_field/bit_field_array.h
+++ b/meta/bit_field/bit_field_array.h
@@ -1,0 +1,49 @@
+/// @file bit_field_array.h
+/// 
+/// Defines the BitFieldArray construct for Alchemy Message Fields.
+/// This is a specialized meta object the keeps track of a series of bit-field 
+/// definitions for a message structure. 
+///
+/// The MIT License(MIT)
+/// @copyright 2014 Paul M Watt
+//  ****************************************************************************
+#ifndef BIT_FIELD_ARRAY_H_INCLUDED
+#define BIT_FIELD_ARRAY_H_INCLUDED
+//  Includes ******************************************************************
+#include <meta/bit_field/compiler.h>
+#include <array>
+
+
+namespace Hg
+{
+
+// ****************************************************************************
+/// Represents a set of fields that provide homogeneous bit-field access to each
+/// of the data values.
+///           
+/// This object requires a Hg bit-field definition for the type definition of
+/// this object. The base integer type that is defined for the bit-field 
+/// will be used to define the type for allocation of memory for the array.
+/// 
+/// Each field allocated in the array will accessible either by the base
+/// integer type or with the bit-field interface provided supplied to the
+/// definition.
+///
+template<typename T,
+         template
+        >
+struct BitFieldArray
+{
+public:
+
+
+private:
+
+
+};
+
+
+} // namespace Hg
+
+
+#endif

--- a/meta/bit_field_list.h
+++ b/meta/bit_field_list.h
@@ -58,6 +58,11 @@ struct BitFieldNode
   typedef typename RootT::value_type                      value_type;
 
   //  Construction ***************************************************************
+  //  ****************************************************************************
+  /// Copy constructor for this type of node.
+  /// This is important because it provides a location that contains the 
+  /// actual integer-type value this field is stored within.
+  ///
   BitFieldNode(const BitFieldNode &rhs)
     : base_type(rhs)
     , m_field( RootT::GetFieldAddress(m_field) )
@@ -68,6 +73,11 @@ struct BitFieldNode
     m_field.attach((value_type*)&rhs.m_field);
   }
 
+  //  ****************************************************************************
+  /// Value constructor 
+  /// This is important because it provides a location that contains the 
+  /// actual integer-type value this field is stored within.
+  ///
   BitFieldNode(value_type &data_field)
     : base_type(data_field)
     , m_field(GetFieldAddress<IndexT>(m_field))
@@ -97,10 +107,12 @@ struct BitFieldNode< RootT, IndexT, OffsetT, MT>
   typedef typename RootT::value_type              value_type;
 
   //  Construction ***************************************************************
+  //  ****************************************************************************
   BitFieldNode(const BitFieldNode &rhs)
     : RootT(rhs)
   { }
 
+  //  ****************************************************************************
   BitFieldNode(value_type &data_field)
     : RootT(data_field)
   { }
@@ -150,21 +162,33 @@ struct BitFieldList
   typedef typename BitFieldNode< RootT, 0, 0, SeqT >      base_type;
 
   //  Construction *************************************************************
+  //  **************************************************************************
+  /// Value constructor.
+  ///
   BitFieldList(value_type &data_field)
     : base_type(data_field)
   { }
 
+  //  **************************************************************************
+  /// Value conversion operator allows the entire integer to be extracted.
+  ///
   operator value_type() const
   {
     return RootT::m_data;
   }
 
+  //  **************************************************************************
+  /// Assignment operator, changes the value but does not change the storage address.
+  ///
   BitFieldList& operator=(const BitFieldList &rhs)
   {
     RootT::m_data = static_cast<RootT>(rhs).m_data;
     return *this;
   }
 
+  //  **************************************************************************
+  /// Assignment operator, changes the value but does not change the storage address.
+  ///
   value_type& operator=(const value_type &rhs)
   {
     RootT::m_data = rhs;
@@ -172,6 +196,9 @@ struct BitFieldList
   }
 
   //  Methods *******************************************************************
+  //  ***************************************************************************
+  /// Returns the size of the base integer type used in the bit list.
+  ///
   static
   size_t size()
   {

--- a/test/TestAlchemyTypes.vcxproj
+++ b/test/TestAlchemyTypes.vcxproj
@@ -132,6 +132,7 @@ cd "../.."</Command>
     <ClInclude Include="..\meta\auto_index.h" />
     <ClInclude Include="..\meta\bit_field\basic_list.h" />
     <ClInclude Include="..\meta\bit_field\bit_field.h" />
+    <ClInclude Include="..\meta\bit_field\bit_field_array.h" />
     <ClInclude Include="..\meta\bit_field_list.h" />
     <ClInclude Include="..\meta\byte_order.h" />
     <ClInclude Include="..\meta\compiler.h" />
@@ -171,6 +172,7 @@ cd "../.."</Command>
     <ClInclude Include="Src\TestMessageSuite.h" />
     <ClInclude Include="Src\TestMeta.h" />
     <ClInclude Include="Src\TestVectorProxySuite.h" />
+    <ClInclude Include="TestBitFieldArray.h" />
     <ClInclude Include="test_def.h" />
     <ClInclude Include="test_helper.h" />
   </ItemGroup>

--- a/test/TestAlchemyTypes.vcxproj.filters
+++ b/test/TestAlchemyTypes.vcxproj.filters
@@ -278,6 +278,12 @@
     <ClInclude Include="..\Hg\datum\datum.h">
       <Filter>Header Files\Alchemy\Hg\Datum</Filter>
     </ClInclude>
+    <ClInclude Include="TestBitFieldArray.h">
+      <Filter>Header Files\Tests</Filter>
+    </ClInclude>
+    <ClInclude Include="..\meta\bit_field\bit_field_array.h">
+      <Filter>Header Files\Alchemy\Meta\bit_field</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Src\Generated\TestAlchemyTypesRunner.cpp">

--- a/test/TestBitFieldArray.h
+++ b/test/TestBitFieldArray.h
@@ -1,0 +1,102 @@
+//  @file Hg.h
+//  
+//  Contains the Hg (Mercury) Message template definition.
+//  This format is used to access data fields in formatted message buffers.
+//  
+//  The MIT License(MIT)
+//  
+//  @copyright 2014 Paul M Watt
+//  
+//  TS_FAIL(message):                        Fail unconditionally
+//  TS_ASSERT(expr):                         Verify (expr) is true
+//  TS_ASSERT_EQUALS(x, y):                  Verify (x==y)
+//  TS_ASSERT_SAME_DATA(x, y, size):         Verify two buffers are equal
+//  TS_ASSERT_DELTA(x, y, d):                Verify (x==y) up to d
+//  TS_ASSERT_DIFFERS(x, y):                 Verify !(x==y)
+//  TS_ASSERT_LESS_THAN(x, y):               Verify (x<y)
+//  TS_ASSERT_LESS_THAN_EQUALS(x, y):        Verify (x<=y)
+//  TS_ASSERT_PREDICATE(P, x):               Verify P(x)
+//  TS_ASSERT_RELATION(R, x, y):             Verify x R y, ex. TS_ASSERT_RELATION(std::greater, x, y);
+//  TS_ASSERT_THROWS(expr, type):            Verify that (expr) throws a specific type of exception.
+//  TS_ASSERT_THROWS_EQUALS(expr, arg, x, y):Verify type and value of what (expr) throws
+//  TS_ASSERT_THROWS_ANYTHING(expr):         Verify that (expr) throws an exception
+//  TS_ASSERT_THROWS_NOTHING(expr):          Verify that (expr) doesn't throw anything
+//  TS_WARN(message):                        Print message as a warning
+//  TS_TRACE(message):                       Print message as an information message
+// 
+#ifndef TESTBITFIELDARRAY_H_INCLUDED
+#define TESTBITFIELDARRAY_H_INCLUDED
+//  Includes *******************************************************************
+#include <cxxtest/TestSuite.h>
+#include <alchemy.h>
+#include <storage_policy.h>
+#include <meta/bit_field_array.h>
+
+#include <test_helper.h>
+#include <test_def.h>
+
+
+namespace Hg
+{
+
+
+
+} // namespace Hg
+
+
+//  ****************************************************************************
+/// @brief TestArrayDataSuite Test Suite class.
+///
+class TestBitFieldArray : public CxxTest::TestSuite
+//  , HgTestHelper<Hg::array_t, Hg::BufferedStoragePolicy >
+{
+public:
+  TestBitFieldArray() { }
+
+  // Fixture Management ********************************************************
+  // setUp will be called before each test case in order to setup common fixtures.
+  virtual void setUp()
+  {
+    
+  }
+ 
+  // tearDown will be called after each test case to clean up common resources.
+  virtual void tearDown()
+  {
+
+  }
+
+protected:
+  //  Constants ****************************************************************
+
+public:
+  //  Test Cases ***************************************************************
+  //  Test the basic function set with a u32 ***********************************
+  void TestDtor(void);
+
+
+};
+
+//  ****************************************************************************
+void TestBitFieldArray::TestDtor(void)
+{
+//  const std::array<uint8_t, 8> k_control = {1,2,3,4,5,6,7,8};
+////  const uint8_t k_control[8] = {1,2,3,4,5,6,7,8};
+//
+//  array_data_8 sut;
+//  sut.set(k_control);
+//
+//  // SUT
+//  // Call the destructor explicitly.
+//  sut.~DataProxy();
+//
+//  // The assigned code should still be present in the datum.
+//  TS_ASSERT_EQUALS(k_control, sut.get());
+}
+
+
+
+
+
+
+#endif


### PR DESCRIPTION
Added comments that state design and intent for the inner bit-field
classes.
This is to facilitate the integration of the specialized class to be
added, BitFieldArray.
The BitFieldArray will manage a continuous range of memory, and provide
shift and mask (bit-field) access to each element in the array as if it
were a bit-field.

The addition of this class will allow the implementation of Hg::Array
and Hg::Vector type to be both correct and efficient.
